### PR TITLE
Commented config options by default

### DIFF
--- a/configs/config.sample
+++ b/configs/config.sample
@@ -7,35 +7,35 @@
 
 [TOOL DEFAULTS] ; Do not change this!
 
-; Optional, comment this if you want to be prompted each time for a user name to use
+; Optional, uncomment this if you don't want to be prompted each time for a user name to use.
 ; Define the rest of the defaults values below to suit.
-SSH_USER_NAME : testuser
+;SSH_USER_NAME : testuser
 
-; Optional, comment this if you want to be prompted each time for a password to use
+; Optional, uncomment this if you don't want to be prompted each time for a password to use.
 ; Cipher text rsa key passphrase or password
 ; To generate the cipher text: ./reach.py --cipher_text=<real password>
-SSH_PASSWORD_CIPHER : XXXXXXXXXXX
+;SSH_PASSWORD_CIPHER : XXXXXXXXXXX
 
-; Optional, comment this if no RSA keys will be used
-SSH_PRIVATE_KEY : /Users/randyo/.ssh/id_rsa
+; Optional, uncomment this to use the specified RSA key.
+;SSH_PRIVATE_KEY : /Users/randyo/.ssh/id_rsa
 
 ; Define default hosts inventory to use.  It needs to be a comma separated file with a header row.
 ; Be sure to define the matching HOST_MARKER (text displayed when processing)
 ; and KEY_COLUMN (IP used for connections) below.
-HOSTS_INPUT_FILE : /Users/randyo/dev/reach_hosts/my_inventory.csv
+;HOSTS_INPUT_FILE : /Users/randyo/dev/reach_hosts/my_inventory.csv
 
 ; Optional, will log in "logs" directory if this is commented.
-LOGS_DIRECTORY : /Users/randyo/dev/reach/logs/
+;LOGS_DIRECTORY : /Users/randyo/dev/reach/logs/
 
 ; Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL : DEBUG
 
 ; Define default key column for the IP address to use for connections.
-KEY_COLUMN : IP Address
+;KEY_COLUMN : IP Address
 
 ; Define the string format displayed when processing hosts.
 ;   $HF_# where # is the column number from the file above.
-HOST_MARKER : $HF_5 - $HF_1: $HF_3
+;HOST_MARKER : $HF_5 - $HF_1: $HF_3
 
 ; Safe to leave all as False or comment. Change to suit.
 SHOW_HOST_DURATION : False


### PR DESCRIPTION
Most options should be commented, i.e. those that are user-specific such as SSH_PRIVATE_KEY or LOGS_DIRECTORY that has your path in it.